### PR TITLE
Integrate MongoDB saving and AI insights for Daily Planner

### DIFF
--- a/src/app/dashboard/daily/page.tsx
+++ b/src/app/dashboard/daily/page.tsx
@@ -1,19 +1,31 @@
 "use client";
 
 import { useEffect, useState } from 'react';
-import { TextInput, Button, Paper, Title, Text, Container, Group, Textarea, Card, Grid, Timeline, ActionIcon } from '@mantine/core';
+import { TextInput, Button, Paper, Title, Text, Container, Group, Textarea, Card, Grid, Timeline, ActionIcon, Loader, Alert } from '@mantine/core';
 import { DatePickerInput } from '@mantine/dates';
 import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
-import { IconCheck, IconMicrophone } from '@tabler/icons-react';
-import { getWeeklyOverview } from './actions';
-import { DailySummary, ErrorSummary } from "@/types/schemas";
+import { IconCheck, IconMicrophone, IconX, IconAlertCircle } from '@tabler/icons-react';
+import { getWeeklyOverview, saveMorningPlan, saveEveningPlan, fetchDailyAIInsights } from './actions';
+import { DailySummary, ErrorSummary, AIInsight } from "@/types/schemas";
+import { useAuth } from '@/lib/auth-context';
+
+interface Insight {
+  title: string;
+  description: string;
+}
 
 export default function DailyPlannerPage() {
+  const { user } = useAuth();
   const [date, setDate] = useState<Date | null>(new Date());
   const [isRecording, setIsRecording] = useState(false);
   const [weeklyOverview, setWeeklyOverview] = useState<DailySummary[] | ErrorSummary[]>([]);
   const [loadingWeeklySummary, setLoadingWeeklySummary] = useState(false);
+  const [isSubmittingMorning, setIsSubmittingMorning] = useState(false);
+  const [isSubmittingEvening, setIsSubmittingEvening] = useState(false);
+  const [aiInsights, setAiInsights] = useState<Insight[] | null>(null);
+  const [isLoadingAIInsights, setIsLoadingAIInsights] = useState(false);
+  const [aiInsightsError, setAiInsightsError] = useState<string | null>(null);
 
   const morningForm = useForm({
     initialValues: {
@@ -33,26 +45,150 @@ export default function DailyPlannerPage() {
     },
   });
 
-  const handleMorningSubmit = (values: typeof morningForm.values) => {
-    // This will be connected to MongoDB in a later step
-    notifications.show({
-      title: 'Morning Plan Saved',
-      message: 'Your morning priorities have been saved',
-      color: 'green',
-      icon: <IconCheck size="1.1rem" />,
-    });
-    console.log('Morning values:', values);
+  const handleMorningSubmit = async (values: typeof morningForm.values) => {
+    if (!user) {
+      notifications.show({
+        title: 'Authentication Error',
+        message: 'You must be logged in to save your morning plan.',
+        color: 'red',
+        icon: <IconX size="1.1rem" />,
+      });
+      return;
+    }
+    if (!date) {
+      notifications.show({
+        title: 'Date Error',
+        message: 'Please select a date to save your morning plan.',
+        color: 'red',
+        icon: <IconX size="1.1rem" />,
+      });
+      return;
+    }
+
+    setIsSubmittingMorning(true);
+    setAiInsights(null); // Clear previous insights
+    setAiInsightsError(null); // Clear previous errors
+    try {
+      const result = await saveMorningPlan(user.uid, date.toISOString(), values);
+      if (result.success) {
+        notifications.show({
+          title: 'Morning Plan Saved',
+          message: result.message || 'Your morning priorities have been saved successfully.',
+          color: 'green',
+          icon: <IconCheck size="1.1rem" />,
+        });
+        // morningForm.reset();
+        triggerAIInsightsFetch();
+      } else {
+        notifications.show({
+          title: 'Save Failed',
+          message: result.message || 'Could not save your morning plan. Please try again.',
+          color: 'red',
+          icon: <IconX size="1.1rem" />,
+        });
+      }
+    } catch (error) {
+      console.error('Error submitting morning plan:', error);
+      notifications.show({
+        title: 'Error',
+        message: 'An unexpected error occurred. Please try again.',
+        color: 'red',
+        icon: <IconX size="1.1rem" />,
+      });
+    } finally {
+      setIsSubmittingMorning(false);
+    }
   };
 
-  const handleEveningSubmit = (values: typeof eveningForm.values) => {
-    // This will be connected to MongoDB in a later step
-    notifications.show({
-      title: 'Evening Reflection Saved',
-      message: 'Your evening reflection has been saved',
-      color: 'green',
-      icon: <IconCheck size="1.1rem" />,
-    });
-    console.log('Evening values:', values);
+  const handleEveningSubmit = async (values: typeof eveningForm.values) => {
+    if (!user) {
+      notifications.show({
+        title: 'Authentication Error',
+        message: 'You must be logged in to save your evening reflection.',
+        color: 'red',
+        icon: <IconX size="1.1rem" />,
+      });
+      return;
+    }
+    if (!date) {
+      notifications.show({
+        title: 'Date Error',
+        message: 'Please select a date to save your evening reflection.',
+        color: 'red',
+        icon: <IconX size="1.1rem" />,
+      });
+      return;
+    }
+
+    setIsSubmittingEvening(true);
+    setAiInsights(null); // Clear previous insights
+    setAiInsightsError(null); // Clear previous errors
+    try {
+      const result = await saveEveningPlan(user.uid, date.toISOString(), values);
+      if (result.success) {
+        notifications.show({
+          title: 'Evening Reflection Saved',
+          message: result.message || 'Your evening reflection has been saved successfully.',
+          color: 'green',
+          icon: <IconCheck size="1.1rem" />,
+        });
+        // eveningForm.reset();
+        triggerAIInsightsFetch();
+      } else {
+        notifications.show({
+          title: 'Save Failed',
+          message: result.message || 'Could not save your evening reflection. Please try again.',
+          color: 'red',
+          icon: <IconX size="1.1rem" />,
+        });
+      }
+    } catch (error) {
+      console.error('Error submitting evening reflection:', error);
+      notifications.show({
+        title: 'Error',
+        message: 'An unexpected error occurred. Please try again.',
+        color: 'red',
+        icon: <IconX size="1.1rem" />,
+      });
+    } finally {
+      setIsSubmittingEvening(false);
+    }
+  };
+
+  const triggerAIInsightsFetch = async () => {
+    if (!user || !date) {
+      setAiInsightsError("User or date not available to fetch insights.");
+      return;
+    }
+    setIsLoadingAIInsights(true);
+    setAiInsightsError(null);
+    try {
+      const insightResult = await fetchDailyAIInsights(user.uid, date.toISOString());
+      if (insightResult.success && insightResult.insights) {
+        setAiInsights(insightResult.insights);
+      } else {
+        setAiInsights([]); // Set to empty array to indicate no insights found or error
+        setAiInsightsError(insightResult.message || "Failed to fetch AI insights.");
+        notifications.show({
+            title: 'AI Insights Error',
+            message: insightResult.message || "Could not retrieve AI insights at this time.",
+            color: 'orange',
+            icon: <IconAlertCircle size="1.1rem" />,
+        });
+      }
+    } catch (error) {
+      console.error('Error fetching AI insights:', error);
+      setAiInsights([]);
+      setAiInsightsError("An unexpected error occurred while fetching AI insights.");
+       notifications.show({
+            title: 'AI Insights Error',
+            message: "An unexpected error occurred while fetching AI insights.",
+            color: 'red',
+            icon: <IconX size="1.1rem" />,
+        });
+    } finally {
+      setIsLoadingAIInsights(false);
+    }
   };
 
   const toggleVoiceRecording = () => {
@@ -161,7 +297,7 @@ export default function DailyPlannerPage() {
                 mb="md"
                 {...morningForm.getInputProps('morningNotes')}
               />
-              <Button type="submit" fullWidth mt="md">
+              <Button type="submit" fullWidth mt="md" loading={isSubmittingMorning}>
                 Save Morning Plan
               </Button>
             </form>
@@ -212,7 +348,7 @@ export default function DailyPlannerPage() {
                 mb="md"
                 {...eveningForm.getInputProps('reflectionNotes')}
               />
-              <Button type="submit" fullWidth mt="md">
+              <Button type="submit" fullWidth mt="md" loading={isSubmittingEvening}>
                 Save Evening Reflection
               </Button>
             </form>
@@ -222,14 +358,30 @@ export default function DailyPlannerPage() {
 
       <Card shadow="sm" p="lg" radius="md" withBorder mb="xl">
         <Title order={2} mb="md">AI Insights</Title>
-        <Text color="dimmed" mb="md">
-          Gemini-powered insights will appear here after you've used the planner for a few days.
-        </Text>
-        <Paper withBorder p="md" radius="md">
-          <Text style={{ fontStyle: 'italic' }}>
-            "Based on your patterns, you're most productive in the mornings. Consider scheduling your most important tasks before noon."
+        {isLoadingAIInsights && (
+          <Group justify="center" mt="md">
+            <Loader />
+            <Text>Generating insights...</Text>
+          </Group>
+        )}
+        {!isLoadingAIInsights && aiInsightsError && (
+          <Alert icon={<IconAlertCircle size="1rem" />} title="Insights Error" color="red" mt="md">
+            {aiInsightsError}
+          </Alert>
+        )}
+        {!isLoadingAIInsights && !aiInsightsError && aiInsights && aiInsights.length > 0 && (
+          aiInsights.map((insight, index) => (
+            <Paper withBorder p="md" radius="md" mt={index > 0 ? "md" : undefined} key={index}>
+              <Text fw={500}>{insight.title}</Text>
+              <Text size="sm" c="dimmed">{insight.description}</Text>
+            </Paper>
+          ))
+        )}
+        {!isLoadingAIInsights && !aiInsightsError && (!aiInsights || aiInsights.length === 0) && (
+          <Text color="dimmed" mt="md">
+            No insights available yet. Save your morning or evening plan to generate new insights.
           </Text>
-        </Paper>
+        )}
       </Card>
 
       <Card shadow="sm" p="lg" radius="md" withBorder>
@@ -256,8 +408,5 @@ export default function DailyPlannerPage() {
       </Card>
     </Container>
   );
-}
-function setLoadingWeeklySummary(arg0: boolean) {
-  throw new Error('Function not implemented.');
 }
 


### PR DESCRIPTION
- Fixed issue where morning and evening plan buttons were not saving to MongoDB.
- Implemented `saveMorningPlan` and `saveEveningPlan` server actions to persist data in the `dailyPlans` collection, handling upserts correctly.
- Updated client-side `handleMorningSubmit` and `handleEveningSubmit` to call these actions, providing user notifications for success/failure and button loading states.
- Added `fetchDailyAIInsights` server action to retrieve the day's plan from MongoDB and query Gemini API for insights using the `generateInsights` function.
- Integrated AI insight display into the Daily Planner page: insights are fetched after successful plan saves and displayed, with appropriate loading and error states.
- Removed an unused variable in `saveMorningPlan` and ensured consistent field initialization on insert.
- Fixed a minor issue with a stray function definition in the daily planner page component.